### PR TITLE
Upgrade Opal and other dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,26 @@
 PATH
   remote: .
   specs:
-    react.rb (0.0.1)
-      opal (~> 0.6.0)
+    react.rb (0.0.2)
+      opal (~> 0.7.0)
       opal-activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
     hike (1.2.3)
-    json (1.8.2)
     multi_json (1.10.1)
-    opal (0.6.3)
-      source_map
-      sprockets
+    opal (0.7.1)
+      hike (~> 1.2)
+      sourcemap (~> 0.1.0)
+      sprockets (>= 2.2.3, < 4.0.0)
+      tilt (~> 1.4)
     opal-activesupport (0.1.0)
       opal (>= 0.5.0, < 1.0.0)
-    opal-jquery (0.2.0)
-      opal (>= 0.5.0, < 1.0.0)
-    opal-rspec (0.3.0.beta3)
-      opal (>= 0.6.0, < 1.0.0)
+    opal-jquery (0.3.0)
+      opal (~> 0.7.0)
+    opal-rspec (0.4.1)
+      opal (~> 0.7.0)
     rack (1.6.0)
     rack-protection (1.5.3)
       rack
@@ -28,8 +29,7 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
-    source_map (3.0.1)
-      json
+    sourcemap (0.1.1)
     sprockets (2.12.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -42,7 +42,7 @@ PLATFORMS
 
 DEPENDENCIES
   opal-jquery
-  opal-rspec (~> 0.3.0.beta3)
+  opal-rspec
   react-source (~> 0.12)
   react.rb!
   sinatra

--- a/lib/react/component.rb
+++ b/lib/react/component.rb
@@ -1,4 +1,4 @@
-require "./ext/string"
+require "react/ext/string"
 require 'active_support/core_ext/class/attribute'
 require 'react/callbacks'
 require "react/ext/hash"

--- a/lib/react/element.rb
+++ b/lib/react/element.rb
@@ -1,4 +1,4 @@
-require "./ext/string"
+require "react/ext/string"
 
 module React
   class Element

--- a/react.rb.gemspec
+++ b/react.rb.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |s|
   s.test_files     = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths  = ['lib', 'vendor']
 
-  s.add_runtime_dependency 'opal', '~> 0.6.0'
+  s.add_runtime_dependency 'opal', '~> 0.7.0'
   s.add_runtime_dependency 'opal-activesupport'
   s.add_development_dependency 'react-source', '~> 0.12'
-  s.add_development_dependency 'opal-rspec', '~> 0.3.0.beta3'
+  s.add_development_dependency 'opal-rspec'
   s.add_development_dependency 'sinatra'
   s.add_development_dependency 'opal-jquery'
 end


### PR DESCRIPTION
Opal 0.7 was released a couple weeks ago, so I upgraded it and a few other dependencies here. This gives better support for source maps — and will allow it to be used with my latest projects based on Opal. ;-)

The only actual code changes I made were due to path-relative `require` statements no longer being valid. I just rewrote them to use canonical paths. Specs are still green, so that's a good sign. :-)
