### PR TITLE
React v0.13 and Opal 0.8

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "opal-rspec"]
 	path = opal-rspec
 	url = https://github.com/wied03/opal-rspec.git
-	branch = opal-0.8-other/rspec-3.1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "opal-rspec"]
+	path = opal-rspec
+	url = https://github.com/wied03/opal-rspec.git
+	branch = opal-0.8-other/rspec-3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ rvm:
 
 before_install:
   - git submodule update --init
-  - cd opal-rspec; git submodule update --init
+  - (cd opal-rspec; git submodule update --init)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+
+before_install:
+  - git submodule update --init
+  - cd opal-rspec; git submodule update --init

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'opal-rspec', git: 'https://github.com/wied03/opal-rspec.git'
-gem 'opal', git: 'https://github.com/wied03/opal.git'
+gem 'opal', git: 'https://github.com/opal/opal.git'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'opal-rspec', git: 'https://github.com/opal/opal-rspec.git'
+gem 'opal-rspec', git: 'https://github.com/wied03/opal-rspec.git'
+gem 'opal', git: 'https://github.com/wied03/opal.git'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'opal-rspec', git: 'https://github.com/wied03/opal-rspec.git'
+gem 'opal-rspec', git: 'https://github.com/wied03/opal-rspec.git', branch: 'opal-0.8-other/rspec-3.1'
 gem 'opal', git: 'https://github.com/opal/opal.git'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'opal-rspec', git: 'https://github.com/wied03/opal-rspec.git', branch: 'opal-0.8-other/rspec-3.1'
-gem 'opal', git: 'https://github.com/opal/opal.git'
+# Until https://github.com/opal/opal/pull/884 is merged, then back to main Opal branch
+gem 'opal', git: 'https://github.com/wied03/opal.git', branch: 'feature/bridge_class_tweak'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,5 @@
 source 'https://rubygems.org'
+
+gem 'opal-rspec', git: 'https://github.com/opal/opal-rspec.git'
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'opal-rspec', git: 'https://github.com/wied03/opal-rspec.git', branch: 'opal-0.8-other/rspec-3.1'
+gem 'opal-rspec', path: './opal-rspec'
 # Until https://github.com/opal/opal/pull/884 is merged, then back to main Opal branch
-gem 'opal', git: 'https://github.com/wied03/opal.git', branch: 'feature/bridge_class_tweak'
+gem 'opal', git: 'https://github.com/opal/opal.git'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 GIT
+  remote: https://github.com/opal/opal.git
+  revision: cf3c410a9abe711d7455d9a0d67c14a834177eb5
+  specs:
+    opal (0.8.0.beta1)
+      hike (~> 1.2)
+      sourcemap (~> 0.1.0)
+      sprockets (~> 3.1)
+      tilt (~> 1.4)
+
+GIT
   remote: https://github.com/wied03/opal-rspec.git
   revision: 617560c4048708712a416697fd598d4f08ee1c20
   specs:
     opal-rspec (0.4.2)
       opal (>= 0.7.0, < 0.9)
-
-GIT
-  remote: https://github.com/wied03/opal.git
-  revision: 91aed7cd76c20ecfba041bebc86d0e49b309de9f
-  specs:
-    opal (0.8.0.beta1)
-      hike (~> 1.2)
-      sourcemap (~> 0.1.0)
-      sprockets (>= 2.2.3, < 4.0.0)
-      tilt (~> 1.4)
 
 PATH
   remote: .

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,24 @@
 GIT
-  remote: https://github.com/opal/opal-rspec.git
+  remote: https://github.com/wied03/opal-rspec.git
   revision: 617560c4048708712a416697fd598d4f08ee1c20
   specs:
     opal-rspec (0.4.2)
       opal (>= 0.7.0, < 0.9)
 
+GIT
+  remote: https://github.com/wied03/opal.git
+  revision: 91aed7cd76c20ecfba041bebc86d0e49b309de9f
+  specs:
+    opal (0.8.0.beta1)
+      hike (~> 1.2)
+      sourcemap (~> 0.1.0)
+      sprockets (>= 2.2.3, < 4.0.0)
+      tilt (~> 1.4)
+
 PATH
   remote: .
   specs:
     react.rb (0.3.0)
-      opal (= 0.8.0.beta1)
       opal-activesupport (~> 0)
       react-jsx (~> 0.8.0)
       react-source (~> 0.13)
@@ -23,11 +32,6 @@ GEM
     hike (1.2.3)
     json (1.8.2)
     libv8 (3.16.14.7)
-    opal (0.8.0.beta1)
-      hike (~> 1.2)
-      sourcemap (~> 0.1.0)
-      sprockets (>= 2.2.3, < 4.0.0)
-      tilt (~> 1.4)
     opal-activesupport (0.1.0)
       opal (>= 0.5.0, < 1.0.0)
     opal-jquery (0.2.0)
@@ -58,6 +62,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  opal!
   opal-jquery (~> 0)
   opal-rspec!
   rake (~> 10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/wied03/opal-rspec.git
-  revision: 617560c4048708712a416697fd598d4f08ee1c20
+  revision: e12bdab34480f598a2db25cf988c1b3a3368dd4c
+  branch: opal-0.8-other/rspec-3.1
   specs:
     opal-rspec (0.4.2)
       opal (>= 0.7.0, < 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,6 @@
 GIT
-  remote: https://github.com/wied03/opal-rspec.git
-  revision: 7e818fb02d97e744efb64f07e340b1e80d0789be
-  branch: opal-0.8-other/rspec-3.1
-  specs:
-    opal-rspec (0.4.2)
-      opal (>= 0.7.0, < 0.9)
-      opal-minitest (~> 0.0)
-
-GIT
-  remote: https://github.com/wied03/opal.git
-  revision: 719a1452594b73b5987ff3455096b68e61ad7659
-  branch: feature/bridge_class_tweak
+  remote: https://github.com/opal/opal.git
+  revision: 4a437686876597ea371917f0129f70296cde01b1
   specs:
     opal (0.8.0.beta1)
       hike (~> 1.2)
@@ -22,11 +12,19 @@ PATH
   remote: .
   specs:
     react.rb (0.3.0)
+      opal (= 0.8.0.beta1)
       opal-activesupport (~> 0)
       react-jsx (~> 0.8.0)
       react-source (~> 0.13)
       sprockets (~> 3.1)
       therubyracer (~> 0)
+
+PATH
+  remote: ./opal-rspec
+  specs:
+    opal-rspec (0.5.0.beta1)
+      opal (>= 0.7.0, < 0.9)
+      opal-minitest (~> 0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
       opal-activesupport (~> 0)
       react-jsx (~> 0.8.0)
       react-source (~> 0.13)
-      sprockets (>= 2.2.3, < 3.0.0)
+      sprockets (~> 3.1)
       therubyracer (~> 0)
 
 GEM
@@ -23,7 +23,6 @@ GEM
     hike (1.2.3)
     json (1.8.2)
     libv8 (3.16.14.7)
-    multi_json (1.11.0)
     opal (0.8.0.beta1)
       hike (~> 1.2)
       sourcemap (~> 0.1.0)
@@ -48,11 +47,8 @@ GEM
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     sourcemap (0.1.1)
-    sprockets (2.12.3)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
+    sprockets (3.1.0)
       rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,22 @@
 GIT
-  remote: https://github.com/opal/opal.git
-  revision: cf3c410a9abe711d7455d9a0d67c14a834177eb5
+  remote: https://github.com/wied03/opal-rspec.git
+  revision: 7e818fb02d97e744efb64f07e340b1e80d0789be
+  branch: opal-0.8-other/rspec-3.1
+  specs:
+    opal-rspec (0.4.2)
+      opal (>= 0.7.0, < 0.9)
+      opal-minitest (~> 0.0)
+
+GIT
+  remote: https://github.com/wied03/opal.git
+  revision: 719a1452594b73b5987ff3455096b68e61ad7659
+  branch: feature/bridge_class_tweak
   specs:
     opal (0.8.0.beta1)
       hike (~> 1.2)
       sourcemap (~> 0.1.0)
       sprockets (~> 3.1)
-      tilt (~> 1.4)
-
-GIT
-  remote: https://github.com/wied03/opal-rspec.git
-  revision: e12bdab34480f598a2db25cf988c1b3a3368dd4c
-  branch: opal-0.8-other/rspec-3.1
-  specs:
-    opal-rspec (0.4.2)
-      opal (>= 0.7.0, < 0.9)
+      tilt (>= 1.4)
 
 PATH
   remote: .
@@ -37,6 +39,9 @@ GEM
       opal (>= 0.5.0, < 1.0.0)
     opal-jquery (0.2.0)
       opal (>= 0.5.0, < 1.0.0)
+    opal-minitest (0.0.4)
+      opal (>= 0.6)
+      rake (~> 10.3)
     rack (1.6.1)
     rack-protection (1.5.3)
       rack
@@ -57,7 +62,7 @@ GEM
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
-    tilt (1.4.1)
+    tilt (2.0.1)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,15 @@
+GIT
+  remote: https://github.com/opal/opal-rspec.git
+  revision: 617560c4048708712a416697fd598d4f08ee1c20
+  specs:
+    opal-rspec (0.4.2)
+      opal (>= 0.7.0, < 0.9)
+
 PATH
   remote: .
   specs:
     react.rb (0.3.0)
-      opal (~> 0.6.0)
+      opal (= 0.8.0.beta1)
       opal-activesupport (~> 0)
       react-jsx (~> 0.8.0)
       react-source (~> 0.13)
@@ -17,16 +24,16 @@ GEM
     json (1.8.2)
     libv8 (3.16.14.7)
     multi_json (1.11.0)
-    opal (0.6.3)
-      source_map
-      sprockets
+    opal (0.8.0.beta1)
+      hike (~> 1.2)
+      sourcemap (~> 0.1.0)
+      sprockets (>= 2.2.3, < 4.0.0)
+      tilt (~> 1.4)
     opal-activesupport (0.1.0)
       opal (>= 0.5.0, < 1.0.0)
     opal-jquery (0.2.0)
       opal (>= 0.5.0, < 1.0.0)
-    opal-rspec (0.3.0.beta3)
-      opal (>= 0.6.0, < 1.0.0)
-    rack (1.6.0)
+    rack (1.6.1)
     rack-protection (1.5.3)
       rack
     rake (10.4.2)
@@ -34,14 +41,13 @@ GEM
       execjs (>= 2.0.2)
       json (>= 1.8.0)
       react-source (>= 0.4.1)
-    react-source (0.13.2)
+    react-source (0.13.3)
     ref (1.0.5)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    source_map (3.0.1)
-      json
+    sourcemap (0.1.1)
     sprockets (2.12.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -57,7 +63,7 @@ PLATFORMS
 
 DEPENDENCIES
   opal-jquery (~> 0)
-  opal-rspec (~> 0.3.0.beta3)
+  opal-rspec!
   rake (~> 10)
   react.rb!
   sinatra (~> 1)

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,6 @@ Opal::RSpec::RakeTask.new(:default) do |s|
   s.append_path Opal::React.bundled_path
   s.append_path 'spec/vendor'
   s.index_path = 'spec/reactjs/index.html.erb'
+  # Without this, we only see sprockets runner in the stack trace
+  s.debug = true
 end

--- a/opal/react/component.rb
+++ b/opal/react/component.rb
@@ -1,4 +1,4 @@
-require "./ext/string"
+require "react/ext/string"
 require 'active_support/core_ext/class/attribute'
 require 'react/callbacks'
 require "react/ext/hash"

--- a/opal/react/component_factory.rb
+++ b/opal/react/component_factory.rb
@@ -9,13 +9,18 @@ module React
     def self.native_component_class(klass)
       klass.class_eval do
         include(React::Component::API)
-        native_alias :componentWillMount, :component_will_mount
-        native_alias :componentDidMount, :component_did_mount
-        native_alias :componentWillReceiveProps, :component_will_receive_props
-        native_alias :shouldComponentUpdate, :should_component_update?
-        native_alias :componentWillUpdate, :component_will_update
-        native_alias :componentDidUpdate, :component_did_update
-        native_alias :componentWillUnmount, :component_will_unmount
+        # In Opal 0.8, native_alias fails if the method isn't there but we don't want to force all of these to be implemented
+        optional_native_alias = lambda do |js, ruby|
+          not_there = `!(#{self}.$$proto['$' + #{ruby}])`
+          native_alias js, ruby unless not_there
+        end
+        optional_native_alias[:componentWillMount, :component_will_mount]
+        optional_native_alias[:componentDidMount, :component_did_mount]
+        optional_native_alias[:componentWillReceiveProps, :component_will_receive_props]
+        optional_native_alias[:shouldComponentUpdate, :should_component_update?]
+        optional_native_alias[:componentWillUpdate, :component_will_update]
+        optional_native_alias[:componentDidUpdate, :component_did_update]
+        optional_native_alias[:componentWillUnmount, :component_will_unmount]
         native_alias :render, :render
       end
       %x{

--- a/opal/react/component_factory.rb
+++ b/opal/react/component_factory.rb
@@ -54,9 +54,9 @@ module React
           this.constructor = ctor; 
           this.state = #{klass.respond_to?(:initial_state) ? klass.initial_state.to_n : `{}`};
           React.Component.apply(this, arguments);
-          #{klass}._alloc.prototype.$initialize.call(this, Opal.Hash.$new(props));
+          #{klass}.$$alloc.prototype.$initialize.call(this, Opal.Hash.$new(props));
         };
-        ctor.prototype = klass._proto;
+        ctor.prototype = klass.$$proto;
         Object.assign(ctor.prototype, React.Component.prototype);    
         ctor.propTypes = #{klass.respond_to?(:prop_types) ? klass.prop_types.to_n : `{}`};
         ctor.defaultProps = #{klass.respond_to?(:default_props) ? klass.default_props.to_n : `{}`};

--- a/opal/react/element.rb
+++ b/opal/react/element.rb
@@ -1,21 +1,22 @@
 require "react/ext/string"
 
-module React
+module React    
   # Need to make the React Element class/prototype inherit from this class
   class Element < %x{
     (function() {
-        var r = React;
-        var f = function() {};
-        var c = r.createClass({
-          render: function() {
-            return null;
-            }
-            });
-        f.prototype = Object.getPrototypeOf(r.createElement(c));
-        return f;
+      // can't get the prototype for this directly, need to go go in a roundabout way
+      var r = React;
+      var c = r.createClass({
+        render: function() {
+          return null;
+          }
+          });
+      var f = function() {};
+      f.prototype = Object.getPrototypeOf(r.createElement(c));
+      return f;       
       }
       )()
-  }
+    }
     def self.new
       raise "use React.create_element instead"
     end
@@ -109,5 +110,5 @@ module React
     def to_n
       self
     end
-  end
+  end  
 end

--- a/opal/react/element.rb
+++ b/opal/react/element.rb
@@ -2,7 +2,18 @@ require "react/ext/string"
 
 module React
   class Element < %x{
-    (function(){var r = React;var f = function(){};var c = r.createClass({render:function(){return null;}});f.prototype = Object.getPrototypeOf(r.createElement(c));return f;})()
+    (function() {
+        var r = React;
+        var f = function() {};
+        var c = r.createClass({
+          render: function() {
+            return null;
+            }
+            });
+        f.prototype = Object.getPrototypeOf(r.createElement(c));
+        return f;
+      }
+      )()
   }
     def self.new
       raise "use React.create_element instead"

--- a/opal/react/element.rb
+++ b/opal/react/element.rb
@@ -1,7 +1,9 @@
 require "react/ext/string"
 
 module React
-  class Element < `(function(){var r = React;var f = function(){};var c = r.createClass({render:function(){return null;}});f.prototype = Object.getPrototypeOf(r.createElement(c));return f;})()`
+  class Element < %x{
+    (function(){var r = React;var f = function(){};var c = r.createClass({render:function(){return null;}});f.prototype = Object.getPrototypeOf(r.createElement(c));return f;})()
+  }
     def self.new
       raise "use React.create_element instead"
     end

--- a/opal/react/element.rb
+++ b/opal/react/element.rb
@@ -1,6 +1,7 @@
 require "react/ext/string"
 
 module React
+  # Need to make the React Element class/prototype inherit from this class
   class Element < %x{
     (function() {
         var r = React;

--- a/opal/react/element.rb
+++ b/opal/react/element.rb
@@ -1,4 +1,4 @@
-require "./ext/string"
+require "react/ext/string"
 
 module React
   class Element < `(function(){var r = React;var f = function(){};var c = r.createClass({render:function(){return null;}});f.prototype = Object.getPrototypeOf(r.createElement(c));return f;})()`

--- a/react.rb.gemspec
+++ b/react.rb.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files     = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths  = ['lib', 'vendor']
 
-  s.add_runtime_dependency 'opal', '0.8.0.beta1'
+  s.add_runtime_dependency 'opal', ['>= 0.7.0', '< 0.9']
   s.add_runtime_dependency 'opal-activesupport', '~> 0'
   s.add_runtime_dependency 'therubyracer', '~> 0'
   s.add_runtime_dependency 'react-jsx', '~> 0.8.0'

--- a/react.rb.gemspec
+++ b/react.rb.gemspec
@@ -16,14 +16,13 @@ Gem::Specification.new do |s|
   s.test_files     = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths  = ['lib', 'vendor']
 
-  s.add_runtime_dependency 'opal', '~> 0.6.0'
+  s.add_runtime_dependency 'opal', '0.8.0.beta1'
   s.add_runtime_dependency 'opal-activesupport', '~> 0'
   s.add_runtime_dependency 'therubyracer', '~> 0'
   s.add_runtime_dependency 'react-jsx', '~> 0.8.0'
   s.add_runtime_dependency 'sprockets', '>= 2.2.3', '< 3.0.0'
   s.add_runtime_dependency 'react-source', '~> 0.13'
 
-  s.add_development_dependency 'opal-rspec', '~> 0.3.0.beta3'
   s.add_development_dependency 'sinatra', '~> 1'
   s.add_development_dependency 'opal-jquery', '~> 0'
   s.add_development_dependency 'rake', '~> 10'

--- a/react.rb.gemspec
+++ b/react.rb.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |s|
   s.test_files     = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths  = ['lib', 'vendor']
 
-  s.add_runtime_dependency 'opal', '0.8.0.beta1'
+  # Use other copy of opal for testing
+  #s.add_runtime_dependency 'opal', '0.8.0.beta1'
   s.add_runtime_dependency 'opal-activesupport', '~> 0'
   s.add_runtime_dependency 'therubyracer', '~> 0'
   s.add_runtime_dependency 'react-jsx', '~> 0.8.0'

--- a/react.rb.gemspec
+++ b/react.rb.gemspec
@@ -16,8 +16,7 @@ Gem::Specification.new do |s|
   s.test_files     = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths  = ['lib', 'vendor']
 
-  # Use other copy of opal for testing
-  #s.add_runtime_dependency 'opal', '0.8.0.beta1'
+  s.add_runtime_dependency 'opal', '0.8.0.beta1'
   s.add_runtime_dependency 'opal-activesupport', '~> 0'
   s.add_runtime_dependency 'therubyracer', '~> 0'
   s.add_runtime_dependency 'react-jsx', '~> 0.8.0'

--- a/react.rb.gemspec
+++ b/react.rb.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'opal-activesupport', '~> 0'
   s.add_runtime_dependency 'therubyracer', '~> 0'
   s.add_runtime_dependency 'react-jsx', '~> 0.8.0'
-  s.add_runtime_dependency 'sprockets', '>= 2.2.3', '< 3.0.0'
+  s.add_runtime_dependency 'sprockets', '~> 3.1'
   s.add_runtime_dependency 'react-source', '~> 0.13'
 
   s.add_development_dependency 'sinatra', '~> 1'

--- a/spec/component_factory_spec.rb
+++ b/spec/component_factory_spec.rb
@@ -12,6 +12,7 @@ describe React::ComponentFactory do
         def component_will_update; end
         def component_did_update; end
         def component_will_unmount; end
+        def render; end
       end
       
       ctor = React::ComponentFactory.native_component_class(Foo)

--- a/spec/component_spec.rb
+++ b/spec/component_spec.rb
@@ -299,9 +299,14 @@ describe React::Component do
           var org_console = window.console;
           window.console = {warn: function(str){log.push(str)}}
         }
-        render_to_document(React.create_element(Foo, bar: 10, lorem: Lorem.new))
-        `window.console = org_console;`
-        expect(`log`).to eq(["Warning: Failed propType: In component `Foo`\nRequired prop `foo` was not specified\nProvided prop `bar` was not the specified type `String`"])
+        
+        begin
+          render_to_document(React.create_element(Foo, bar: 10, lorem: Lorem.new))
+        
+          expect(`log`).to eq(["Warning: Failed propType: In component `Foo`\nRequired prop `foo` was not specified\nProvided prop `bar` was not the specified type `String`"])          
+        ensure
+          `window.console = org_console;`
+        end
       end
 
       it "should not log anything if validation pass" do
@@ -321,9 +326,12 @@ describe React::Component do
           var org_console = window.console;
           window.console = {warn: function(str){log.push(str)}}
         }
-        render_to_document(React.create_element(Foo, foo: 10, bar: "10", lorem: Lorem.new))
-        `window.console = org_console;`
-        expect(`log`).to eq([])
+        begin
+          render_to_document(React.create_element(Foo, foo: 10, bar: "10", lorem: Lorem.new))        
+          expect(`log`).to eq([])
+        ensure
+          `window.console = org_console;`
+        end        
       end
     end
 

--- a/spec/debug_formatter.rb
+++ b/spec/debug_formatter.rb
@@ -1,0 +1,11 @@
+class DebugFormatter < ::Opal::RSpec::TextFormatter
+  # Include the stack trace
+  def dump_failure_info(example)
+    exception = example.execution_result[:exception]
+    exception_class_name = exception.class.name.to_s
+    red "#{long_padding}#{exception_class_name}:"
+    message_lines = exception.message.to_s.split("\n")
+    message_lines << exception.backtrace
+    message_lines.each { |line| red "#{long_padding}  #{line}" }
+  end      
+end  

--- a/spec/element_collision.rb
+++ b/spec/element_collision.rb
@@ -1,0 +1,5 @@
+class Element
+  def do_stuff
+    'nope'
+  end
+end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -1,9 +1,11 @@
 require "spec_helper"
 
 describe React::Element do
-  # Don't want to step on opal-jquery's Element class
-  it "should not define a top level Element class" do
-    expect(::Element).to be_nil
+  context 'existing Element object defined' do    
+    subject { Element.new.do_stuff }
+    
+    # Don't want to step on opal-jquery's Element class, Opal bridged class get defined at the root scope
+    it { is_expected.to eq 'nope'}
   end
   
   it "should be toll-free bridged to React.Element" do
@@ -12,7 +14,7 @@ describe React::Element do
   end
   
   describe "#new" do
-    it "should raise error if invokded" do
+    it "should raise error if invoked" do
       expect { React::Element.new }.to raise_error
     end
   end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -1,6 +1,11 @@
 require "spec_helper"
 
 describe React::Element do
+  # Don't want to step on opal-jquery's Element class
+  it "should not define a top level Element class" do
+    expect(::Element).to be_nil
+  end
+  
   it "should be toll-free bridged to React.Element" do
     element = React.create_element('div')
     expect(`React.isValidElement(#{element})`).to eq(true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'element_collision'
 require 'react'
 require 'react/testing'
 require 'debug_formatter'
@@ -10,3 +11,4 @@ RSpec.configure do |config|
   # Want some stack traces
   config.formatter = DebugFormatter
 end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,12 @@
 require 'react'
 require 'react/testing'
+require 'debug_formatter'
 
 RSpec.configure do |config|
   config.include React::Testing
   config.after :each do
     React::ComponentFactory.clear_component_class_cache
   end
+  # Want some stack traces
+  config.formatter = DebugFormatter
 end


### PR DESCRIPTION
This is not meant to be a final pull request (just a discussion kickoff).

The main fixes I made here are:
- Adapt to native_alias changes
- Made tests that alter console.log a bit more robust
- Build on ext/string work that someone else already noted

I had to try and fix an issue in Opal itself and that pull request is pending. In order to use my draft/fixed code, this project is currently pointing at my forks of opal and opal-rspec.

Anyways, hopefully this helps with talking about migration approaches, etc.
