### PR TITLE
Opal 0.8 - WIP noise reducing syntax changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gemspec
+gem 'opal', :git => "https://github.com/catprintlabs/opal.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,46 +1,48 @@
+GIT
+  remote: https://github.com/catprintlabs/opal.git
+  revision: 3682db6f2b23a584787a68d5338a7ee9cb35565a
+  specs:
+    opal (0.7.1)
+      hike (~> 1.2)
+      sourcemap (~> 0.1.0)
+      sprockets (>= 2.2.3, < 4.0.0)
+      tilt (~> 1.4)
+
 PATH
   remote: .
   specs:
     react.rb (0.0.2)
-      opal (~> 0.7.0)
+      opal
       opal-activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
     hike (1.2.3)
-    multi_json (1.10.1)
-    opal (0.7.1)
-      hike (~> 1.2)
-      sourcemap (~> 0.1.0)
-      sprockets (>= 2.2.3, < 4.0.0)
-      tilt (~> 1.4)
     opal-activesupport (0.1.0)
       opal (>= 0.5.0, < 1.0.0)
     opal-jquery (0.3.0)
       opal (~> 0.7.0)
-    opal-rspec (0.4.1)
+    opal-rspec (0.4.2)
       opal (~> 0.7.0)
     rack (1.6.0)
     rack-protection (1.5.3)
       rack
-    react-source (0.12.2)
-    sinatra (1.4.5)
+    react-source (0.13.2)
+    sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
+      tilt (>= 1.3, < 3)
     sourcemap (0.1.1)
-    sprockets (2.12.3)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
+    sprockets (3.0.3)
       rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
     tilt (1.4.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  opal!
   opal-jquery
   opal-rspec
   react-source (~> 0.12)

--- a/lib/react.rb
+++ b/lib/react.rb
@@ -1,6 +1,7 @@
 if RUBY_ENGINE == 'opal'
   require "react/top_level"
-  require "react/component"
+  require "react/component"  
+  require "react/top_level_component"
   require "react/element"
   require "react/event"
   require "react/version"

--- a/lib/react/component.rb
+++ b/lib/react/component.rb
@@ -192,7 +192,7 @@ module React
           # getter
           define_method("#{name}") do
             return unless @native
-            self.state[name]
+            self.state.merge(@_react_component_current_state || {})[name]
           end
           # setter
           define_method("#{name}=") do |new_state|
@@ -200,7 +200,8 @@ module React
             hash = {}
             hash[name] = new_state
             self.set_state(hash)
-
+            @_react_component_current_state ||= {}
+            @_react_component_current_state.merge!(hash)
             new_state
           end
           # use my_state! when side effects are expected.  my_state! << 12 << 13 for example
@@ -212,6 +213,7 @@ module React
               self.send("#{name}=", args[0])
               current_value
             else
+              self.send("#{name}=", self.send("#{name}"))
               AutoCallBack.new(self.state[name], lambda { |updated_value| self.send("#{name}=", updated_value)})
             end
           end

--- a/lib/react/top_level.rb
+++ b/lib/react/top_level.rb
@@ -1,5 +1,6 @@
 require "native"
 require 'active_support'
+require 'react/component'
 
 module React
   HTML_TAGS = %w(a abbr address area article aside audio b base bdi bdo big blockquote body br
@@ -53,4 +54,5 @@ module React
   def self.unmount_component_at_node(node)
     `React.unmountComponentAtNode(node.$$class ? node[0] : node)`
   end
+  
 end

--- a/lib/react/top_level.rb
+++ b/lib/react/top_level.rb
@@ -32,6 +32,7 @@ module React
   end
 
   def self.render(element, container)
+    container = `container.$$class ? container[0] : container`
     component = Native(`React.render(#{element.to_n}, container, function(){#{yield if block_given?}})`)
     component.class.include(React::Component::API)
     component
@@ -50,6 +51,6 @@ module React
   end
 
   def self.unmount_component_at_node(node)
-    `React.unmountComponentAtNode(node)`
+    `React.unmountComponentAtNode(node.$$class ? node[0] : node)`
   end
 end

--- a/lib/react/top_level.rb
+++ b/lib/react/top_level.rb
@@ -22,6 +22,11 @@ module React
                 selected shape size sizes span spellCheck src srcDoc srcSet start step style
                 tabIndex target title type useMap value width wmode dangerouslySetInnerHTML)
 
+  def self.component?(name)
+    component = Module.const_get(name.camelize)
+    component if component.method_defined? :render
+  end
+  
   def self.create_element(type, properties = {}, &block)
     React::API.create_element(type, properties, &block)
   end

--- a/lib/react/validator.rb
+++ b/lib/react/validator.rb
@@ -1,9 +1,13 @@
 module React
   class Validator
+    
     def self.build(&block)
-      validator = self.new
-      validator.instance_eval(&block)
-      validator
+      self.new.build(&block)
+    end
+    
+    def build(&block)
+      instance_eval(&block)
+      self
     end
 
     def initialize

--- a/react.rb.gemspec
+++ b/react.rb.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files     = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths  = ['lib', 'vendor']
 
-  s.add_runtime_dependency 'opal', '~> 0.7.0'
+  s.add_runtime_dependency 'opal'#, '~> 0.7.0'
   s.add_runtime_dependency 'opal-activesupport'
   s.add_development_dependency 'react-source', '~> 0.12'
   s.add_development_dependency 'opal-rspec'

--- a/spec/component_spec.rb
+++ b/spec/component_spec.rb
@@ -351,7 +351,7 @@ describe React::Component do
         }
         renderToDocument(Foo, bar: 10, lorem: Lorem.new)
         `window.console = org_console;`
-        expect(`log`).to eq(["Warning: In component `Foo`\nRequired prop `foo` was not specified\nProvided prop `bar` was not the specified type `String`"])
+        expect(`log`).to eq(["Warning: Failed propType: In component `Foo`\nRequired prop `foo` was not specified\nProvided prop `bar` was not the specified type `String`"])
       end
 
       it "should not log anything if validation pass" do

--- a/spec/reactjs/index.html.erb
+++ b/spec/reactjs/index.html.erb
@@ -6,5 +6,6 @@
   <%= javascript_include_tag 'react-with-addons' %>
   <%= javascript_include_tag @server.main %>
   <div id="placeholder" style="display: none"></div>
+  <div id="render_here"></div>
 </body>
 </html>

--- a/spec/tutorial/tutorial_spec.rb
+++ b/spec/tutorial/tutorial_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+  
+class HelloMessage
+  include React::Component
+  def render
+    div { "Hello World!" }
+  end
+end
+  
+describe "An Example from the react.rb doc" do
+  
+  it "produces the correct result" do
+    expect(React.render_to_static_markup(React.create_element(HelloMessage))).to eq('<div>Hello World!</div>')
+  end
+  
+end
+
+class HelloMessage2
+  include React::Component
+  define_state(:user_name) { '@catmando' }
+  def render
+    div { "Hello #{user_name}" }
+  end
+end
+
+describe "Adding state to a component (second tutorial example)" do
+  
+  it "produces the correct result" do
+    expect(React.render_to_static_markup(React.create_element(HelloMessage2))).to eq('<div>Hello @catmando</div>')
+  end
+  
+  it "renders to the document" do
+    React.render(React.create_element(HelloMessage2), `document.getElementById('render_here')`)
+    expect(`document.getElementById('render_here').innerHTML`) =~ 'Hello @catmando'
+  end
+  
+end


### PR DESCRIPTION
This is WIP, just to see what you think of the changes.
For now its using my own copy of opal that better source mapping than the current version 0.7... 

Summary of changes for discussion:

Any class with a render method can be used in the dsl by using the class name with underscores.  I.e. 

```ruby
class MyComponent
  ...
end

class ParentComponent
  def render
    div do 
      my_component param1: 'foo' # works same as presents MyComponent ...
    end
  end
end
```
params can be specified as one liner (similar to state, and rails attributes etc.)
```ruby
required_param :foo   
optional_param :bar, default: "xyz"
```
params get their own read accessors just like state, so you can say
```ruby
puts foo
puts bar
```
params with type `Proc`, can be called inside the component without using call.
```ruby
required_param :inform_of_update, type: Proc
...
   inform_of_update "new text string"
```
state can now be updated by using the ! methods.  
```ruby
some_state!  12 # state now updated to 12, returns the previous value
some_state!   # without a param returns an object that will observe any changes to some_state
some_state! << 12 << 13 # assuming some_state is an array for example

```
the object returned by some_state! will also respond to :call, this allows 
simple 2 way binding.  So you can write
```
  my_component inform_of_update: my_state!   
  # compare to the equivalent
  present MyComponent, inform_of_update: -> (x) { self.my_state = x }
```
A copy of the current state is kept, so it can be read during events.
*ReactJS does not guarantee the value of state being stable until after 
the event completes.* 
So now its safe to write
```
   my_state! get_new_value
   my_state.each do { ... } #etc
# instead of
   temp = get_new_value
   temp.each do { ... } #etc
```
The React.render method can be passed a Opal Element directly (no need to do a get(0).  
```ruby
  React.render(element, Element['#todoapp'])
# works the same as
  React.render(element, Element['#todoapp'].get(0)) # this still works
```
There is a React::TopLevelComponent class.  This provides several features:

1. ability to create multiple react components mounted in various places on a single page and communicating.  Very handy for evolving from other frameworks, as it allows subsections of the page to be redone as components.
2. automatically mounts the components on DOM ready
3. provides a safe mechanism to communicate from outside the React structure

```ruby
class App < React::TopLevelComponent
  
  define_state :text do "I have never been clicked" end
  
  mount_component FriendsContainer, 'div#placeholder'
  mount_component JustSomeText, 'div#placeholder2' do {text: text} end
    
  external_update :update_text do |new_text| text! new_text end
end
```
elsewhere in old js code you can say
```javascript
 $(document).ready(function() {
  var n = 0;
  $('#jquery-button').click(function() {    
    Opal.App.$update_text("I have been clicked "+n+"times")
  }}
```
Any calls to external updates will be queued until the top level component is mounted

Well I think that's it... interested in what you think... I am using all these changes for my main company app, and should be deploying soon, so you can see it live in action.

I am happy to write the docs, update the samples, and of course write tests for all these.






