### PR TITLE
Allow multiple invocations of params without losing rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.1
+*  Invoking params multiple times will append to the existing parameters
+
 ## 0.3.0
 *  Depends on `sprockets < 3` thus source map can still work
 *  Remove sprockets-es6 from dependency

--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ class App
     optional :filters, type: Array[String]
     optional :flash_message, type: String, default: 'Welcome!' # no need to feed through `getDefaultProps`
   end
+	
+	# Will append to the params above
+	params do
+		requires :password, type: String
+	end
 
   def render
     div

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ class App
   end
 	
 	# Will append to the params above
-	params do
-		requires :password, type: String
-	end
+  params do
+    requires :password, type: String
+  end
 
   def render
     div

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ class App
     optional :flash_message, type: String, default: 'Welcome!' # no need to feed through `getDefaultProps`
   end
 	
-	# Will append to the params above
+  # Will append to the params above
   params do
     requires :password, type: String
   end

--- a/lib/react/component.rb
+++ b/lib/react/component.rb
@@ -132,7 +132,11 @@ module React
       end
 
       def params(&block)
-        self.validator = React::Validator.build(&block)
+        if self.validator
+          self.validator.evaluate_more_rules(&block)
+        else
+          self.validator = React::Validator.build(&block)
+        end
       end
 
       def define_state(*states)

--- a/lib/react/validator.rb
+++ b/lib/react/validator.rb
@@ -9,6 +9,10 @@ module React
     def initialize
       @rules = {}
     end
+    
+    def evaluate_more_rules(&block)
+       self.instance_eval(&block)
+    end
 
     def requires(prop_name, options = {})
       rule = options

--- a/spec/component_spec.rb
+++ b/spec/component_spec.rb
@@ -353,6 +353,31 @@ describe React::Component do
         `window.console = org_console;`
         expect(`log`).to eq(["Warning: In component `Foo`\nRequired prop `foo` was not specified\nProvided prop `bar` was not the specified type `String`"])
       end
+      
+      it "should allow params to be appended to" do
+        stub_const 'Lorem', Class.new
+        Foo.class_eval do
+          params do
+            requires :foo
+            requires :lorem, type: Lorem
+          end
+          
+          params do
+           optional :bar, type: String
+          end
+
+          def render; div; end
+        end
+        
+        %x{
+          var log = [];
+          var org_console = window.console;
+          window.console = {warn: function(str){log.push(str)}}
+        }
+        renderToDocument(Foo, bar: 10, lorem: Lorem.new)
+        `window.console = org_console;`
+        expect(`log`).to eq(["Warning: In component `Foo`\nRequired prop `foo` was not specified\nProvided prop `bar` was not the specified type `String`"])
+      end
 
       it "should not log anything if validation pass" do
         stub_const 'Lorem', Class.new


### PR DESCRIPTION
Allow multiple invocations of params without losing rules (for example if a mixin defines some params and a class wants to add to them)
