### PR TITLE
Change ./ext/string requires to react/ext/string

### DIFF
--- a/lib/react/component.rb
+++ b/lib/react/component.rb
@@ -1,4 +1,4 @@
-require "./ext/string"
+require "react/ext/string"
 require 'active_support/core_ext/class/attribute'
 require 'react/callbacks'
 require "react/ext/hash"

--- a/lib/react/element.rb
+++ b/lib/react/element.rb
@@ -1,31 +1,31 @@
-require "./ext/string"
+require "react/ext/string"
 
 module React
   class Element < `(function(){var r = React;var f = function(){};var c = r.createClass({render:function(){return null;}});f.prototype = Object.getPrototypeOf(r.createElement(c));return f;})()`
     def self.new
       raise "use React.create_element instead"
     end
-    
+
     def element_type
       `self.type`
     end
-    
+
     def key
       Native(`self.key`)
     end
-    
+
     def props
       Hash.new(`self.props`)
     end
-    
+
     def ref
       Native(`self.ref`)
     end
-    
+
     def on(event_name)
       name = event_name.to_s.event_camelize
-      
-      
+
+
       if React::Event::BUILT_IN_EVENTS.include?("on#{name}")
         prop_key = "on#{name}"
         callback =  %x{
@@ -41,15 +41,15 @@ module React
           }
         }
       end
-      
+
       `self.props[#{prop_key}] = #{callback}`
-      
+
       self
     end
 
     def children
       nodes = `self.props.children`
-      
+
       if `React.Children.count(nodes)` == 0
         `[]`
       elsif `React.Children.count(nodes)` == 1
@@ -85,11 +85,11 @@ module React
             end
           end
         end
-        
+
         nodes
       end
     end
-  
+
     def to_n
       self
     end


### PR DESCRIPTION
I've found that there is a require error trying to bundle the code if the the ext/string path is not absolute (gem dir / path)

I think it works well when you are requiring the gem via `path: "./.."` like you do in the examples (in fact they work) but it breaks otherwise

fiy I'm on 2.1.6

Here's how to reproduce:

Gemfile

``` rb
source "http://rubygems.org"

gem "react.rb", github: "zetachang/react.rb"
```

build.rb

``` rb
require 'bundler'
Bundler.require

Opal::Builder.build('react')
```

run: 

```
bundle && ruby build.rb
```

this pr should fix it

there is also some whitespace removal, If you want I can take it out from this PR and have just the two require lines as modified

also, very cool library! I will start to play with it soon! thanks! 
