### PR TITLE
React native support using opal 0.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,26 @@
 PATH
   remote: .
   specs:
-    react.rb (0.0.1)
-      opal (~> 0.6.0)
+    react.rb (0.0.2)
+      opal (~> 0.7.0)
       opal-activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
     hike (1.2.3)
-    json (1.8.2)
     multi_json (1.10.1)
-    opal (0.6.3)
-      source_map
-      sprockets
+    opal (0.7.1)
+      hike (~> 1.2)
+      sourcemap (~> 0.1.0)
+      sprockets (>= 2.2.3, < 4.0.0)
+      tilt (~> 1.4)
     opal-activesupport (0.1.0)
       opal (>= 0.5.0, < 1.0.0)
-    opal-jquery (0.2.0)
-      opal (>= 0.5.0, < 1.0.0)
-    opal-rspec (0.3.0.beta3)
-      opal (>= 0.6.0, < 1.0.0)
+    opal-jquery (0.3.0)
+      opal (~> 0.7.0)
+    opal-rspec (0.4.1)
+      opal (~> 0.7.0)
     rack (1.6.0)
     rack-protection (1.5.3)
       rack
@@ -28,8 +29,7 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
-    source_map (3.0.1)
-      json
+    sourcemap (0.1.1)
     sprockets (2.12.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -42,7 +42,7 @@ PLATFORMS
 
 DEPENDENCIES
   opal-jquery
-  opal-rspec (~> 0.3.0.beta3)
+  opal-rspec
   react-source (~> 0.12)
   react.rb!
   sinatra

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,6 @@ GEM
     execjs (2.5.2)
     hike (1.2.3)
     libv8 (3.16.14.7)
-    multi_json (1.11.0)
     opal (0.7.2)
       hike (~> 1.2)
       sourcemap (~> 0.1.0)

--- a/lib/react/component.rb
+++ b/lib/react/component.rb
@@ -1,4 +1,4 @@
-require "./ext/string"
+require "react/ext/string"
 require 'active_support/core_ext/class/attribute'
 require 'react/callbacks'
 require "react/ext/hash"

--- a/lib/react/component_factory.rb
+++ b/lib/react/component_factory.rb
@@ -13,13 +13,13 @@ module React
         native_alias :render, :render
       end
       %x{
-        function ctor(){
+        function ctor(props){
           this.constructor = ctor; 
           this.state = #{klass.respond_to?(:initial_state) ? klass.initial_state.to_n : `{}`};
           React.Component.apply(this, arguments);
-          #{klass}._alloc.prototype.$initialize.call(this);
+          #{klass}.$$alloc.prototype.$initialize.call(this, Opal.Hash.$new(props));
         };
-        ctor.prototype = klass._proto;
+        ctor.prototype = klass.$$proto;
         Object.assign(ctor.prototype, React.Component.prototype);    
         ctor.propTypes = #{klass.respond_to?(:prop_types) ? klass.prop_types.to_n : `{}`};
         ctor.defaultProps = #{klass.respond_to?(:default_props) ? klass.default_props.to_n : `{}`};

--- a/lib/react/element.rb
+++ b/lib/react/element.rb
@@ -1,4 +1,4 @@
-require "./ext/string"
+require "react/ext/string"
 
 module React
   class Element

--- a/react.rb.gemspec
+++ b/react.rb.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |s|
   s.test_files     = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths  = ['lib', 'vendor']
 
-  s.add_runtime_dependency 'opal', '~> 0.6.0'
+  s.add_runtime_dependency 'opal', '~> 0.7.0'
   s.add_runtime_dependency 'opal-activesupport'
   s.add_development_dependency 'react-source', '~> 0.12'
-  s.add_development_dependency 'opal-rspec', '~> 0.3.0.beta3'
+  s.add_development_dependency 'opal-rspec'
   s.add_development_dependency 'sinatra'
   s.add_development_dependency 'opal-jquery'
 end


### PR DESCRIPTION
Fix React::ComponentFactory.native_component_class to work with opal 0.7.0
