### PR TITLE
fix Railtie configuration for Rails 3.2.x

### DIFF
--- a/lib/rails-helpers/react_component.rb
+++ b/lib/rails-helpers/react_component.rb
@@ -16,9 +16,9 @@ begin
   module React
     
     class Railtie < ::Rails::Railtie
-      config.before_configuration do
-        config.assets.enabled = true
-        config.assets.paths << ::Rails.root.join('app', 'views').to_s
+      config.before_configuration do |app|
+        app.config.assets.enabled = true
+        app.config.assets.paths << ::Rails.root.join('app', 'views').to_s
       end
     end
     


### PR DESCRIPTION
Fixes:
`NoMethodError: undefined method 'assets' for #<Rails::Railtie::Configuration:0x007fa2ef4370a8>`

Tested using reactive-record's specs.
